### PR TITLE
Changed `self.ignore_file_list_pat` to ignore empty list

### DIFF
--- a/ndg/security/server/wsgi/authz/pep.py
+++ b/ndg/security/server/wsgi/authz/pep.py
@@ -410,7 +410,7 @@ class SamlPepFilterBase(SessionMiddlewareBase):
         """
         # Apply a list of regular expressions to filter out files which can be 
         # ignored
-        if self.ignore_file_list_pat is not None:
+        if self.ignore_file_list_pat:
             for pat in self.ignore_file_list_pat:
                 if re.match(pat, resourceURI):
                     return False


### PR DESCRIPTION
Changed checking of `self.ignore_file_list_pat` from `is not None` to just `if self.ignore_file_list_pat`.

This overcomes a problem in the CEDA WPS where the empty list was triggering the wrong block to execute and then the content of the `request-filter` was being ignored in the local configuration (to defined regexes to accept without a security check).